### PR TITLE
Abstract default username

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -12,3 +12,5 @@ common_apt_packages:
 tbb_arch: 64
 tbb_release: 5.5.4
 tbb_locale: en-US
+
+tbb_username: "{{ ansible_ssh_user }}"

--- a/roles/common/tasks/download-verify-tbb.yml
+++ b/roles/common/tasks/download-verify-tbb.yml
@@ -1,17 +1,18 @@
 ---
 - name: Create ~/.tbb folder
   file:
-    path: /home/vagrant/tor-browser-crawler/tbb/
+    path: "~{{ tbb_username }}/tor-browser-crawler/tbb/"
     state: directory
     mode: 0755
 
 - name: Download TBB tarball and signature.
   get_url:
     url: "{{ item }}"
-    dest: /home/vagrant/tor-browser-crawler/tbb/
+    dest: "~{{ tbb_username }}/tor-browser-crawler/tbb/"
   with_items:
     - https://dist.torproject.org/torbrowser/{{ tbb_release }}/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz
     - https://dist.torproject.org/torbrowser/{{ tbb_release }}/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz.asc
+
 - name: Download TBB signing key.
   command: gpg --keyserver hkps://keyserver.cns.vt.edu --recv-key EF6E286DDA85EA2A4BA7DE684E2C6E8793298290
   register: gpg_import_tor_browser_devs_key_result
@@ -22,7 +23,7 @@
   register: gpg_verify_result
   changed_when: false
   args:
-    chdir: /home/vagrant/tor-browser-crawler/tbb/
+    chdir: "~{{ tbb_username }}/tor-browser-crawler/tbb/"
 
 # The unarchive module is relying on tar's --diff option, which does not check
 # file hashes, just that the same filenames are present. Thus you can change a
@@ -33,21 +34,21 @@
 
 - name: Remove the dir the TBB tarball will be extracted to.
   file:
-    path: /home/vagrant/tor-browser-crawler/tbb/tor-browser_en-US/
+    path: "~{{ tbb_username }}/tor-browser-crawler/tbb/tor-browser_en-US/"
     state: absent
 
 - name: Extract TBB archive.
   unarchive:
     copy: no
-    src: /home/vagrant/tor-browser-crawler/tbb/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz
-    dest: /home/vagrant/tor-browser-crawler/tbb/
+    src: "~{{ tbb_username }}/tor-browser-crawler/tbb/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}.tar.xz"
+    dest: "~{{ tbb_username }}/tor-browser-crawler/tbb/"
 
 - name: Remove directory tor-browser-crawler wants this version of TBB extracted to.
   file:
-    path: /home/vagrant/tor-browser-crawler/tbb/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}/
+    path: "~{{ tbb_username }}/tor-browser-crawler/tbb/tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}/"
     state: absent
 
 - name: Move the extracted TBB tarball to the directory tor-browser-crawler wants for this version.
   command: mv tor-browser_en-US/ tor-browser-linux{{ tbb_arch }}-{{ tbb_release }}_{{ tbb_locale }}
   args:
-    chdir: /home/vagrant/tor-browser-crawler/tbb/
+    chdir: "~{{ tbb_username }}/tor-browser-crawler/tbb/"

--- a/roles/common/tasks/source-virtualenvwrapper.yml
+++ b/roles/common/tasks/source-virtualenvwrapper.yml
@@ -1,6 +1,6 @@
 ---
 - name: Source virtualenvwrapper script via bashrc.
   lineinfile:
-    dest: /home/vagrant/.bashrc
+    dest: "~{{ tbb_username }}/.bashrc"
     line: source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
     state: present

--- a/roles/tb-crawler/defaults/main.yml
+++ b/roles/tb-crawler/defaults/main.yml
@@ -3,3 +3,5 @@ tb_crawler_apt_packages:
   - tcpdump
   - wireshark
   - xvfb
+
+tbb_username: "{{ ansible_ssh_user }}"

--- a/roles/tb-crawler/tasks/install-python-deps.yml
+++ b/roles/tb-crawler/tasks/install-python-deps.yml
@@ -1,11 +1,11 @@
 ---
 - name: Check if tb-crawler virtual environment exists.
   stat:
-    path: /home/vagrant/.virtualenvs/tb-crawler/
+    path: "~{{ tbb_username }}/.virtualenvs/tb-crawler/"
   register: tb_crawler_virtualenv
 
 - name: Install tor-browser-crawler pip dependencies to tb-crawler virtualenv.
   pip:
-    requirements: /home/vagrant/tor-browser-crawler/requirements.txt
-    virtualenv: /home/vagrant/.virtualenvs/tb-crawler/
+    requirements: "~{{ tbb_username }}/tor-browser-crawler/requirements.txt"
+    virtualenv: "~{{ tbb_username }}/.virtualenvs/tb-crawler"
     virtualenv_python: python2.7


### PR DESCRIPTION
Can't assume the username is vagrant, won't work with non-vagrant environments. A sane default is the SSH username used for the Ansible connection. If that's not good enough, simply override the `tbb_username` var and set it to the username you wish to configure the dev environment for. The same var name is used for both roles in this repo.
